### PR TITLE
fix: group security updates, park them for 3 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 1
+      default-days: 3
     labels:
       - "dependencies"
       - "github_actions"
@@ -36,6 +36,10 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+          - major
 
   # Docker - weekly updates
   - package-ecosystem: docker
@@ -62,7 +66,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 1
+      default-days: 3
     labels:
       - "dependencies"
       - "docker"
@@ -72,6 +76,10 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+          - major
 
   # NPM & Yarn - weekly updates
   - package-ecosystem: npm
@@ -109,7 +117,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 1
+      default-days: 3
     labels:
       - "dependencies"
       - "npm"
@@ -119,3 +127,7 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+          - major


### PR DESCRIPTION
Reconfigure dependabot to:
* park security updates for 3 days
* group security updates to reduce noice